### PR TITLE
Fix missing spectrum frequency entry redraw

### DIFF
--- a/app/spectrum.c
+++ b/app/spectrum.c
@@ -940,6 +940,7 @@ static void OnKeyDownFreqInput(uint8_t key) {
             }
             break;
     }
+    redrawScreen = true;
 }
 
 static void RenderFreqInput() {


### PR DESCRIPTION
Hello, in present mod firmware, when pressing 5 the input for frequency does not visually react on any key input. After going through the code and debugging, I found out that redraw is not requested at the end of OnKeyDownFreqInput, with it present the frequency input works as expected.