### PR TITLE
Disable timeout on freq/ctcss scan and preserve channel name when saved

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ ENABLE_SWD := 0
 ENABLE_TX1750 := 1
 ENABLE_UART := 1
 ENABLE_NOSCANTIMEOUT := 1
+ENABLE_KEEPNAMEONSAVE := 1
 
 BSP_DEFINITIONS := $(wildcard hardware/*/*.def)
 BSP_HEADERS := $(patsubst hardware/%,bsp/%,$(BSP_DEFINITIONS))
@@ -157,6 +158,9 @@ endif
 LDFLAGS = -mcpu=cortex-m0 -nostartfiles -Wl,-T,firmware.ld
 ifeq ($(ENABLE_NOSCANTIMEOUT),1)
 CFLAGS += -DENABLE_NOSCANTIMEOUT
+endif
+ifeq ($(ENABLE_KEEPNAMEONSAVE),1)
+CFLAGS += -DENABLE_KEEPNAMEONSAVE
 endif
 
 ifeq ($(DEBUG),1)

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ ENABLE_SPECTRUM := 1
 ENABLE_SWD := 0
 ENABLE_TX1750 := 1
 ENABLE_UART := 1
+ENABLE_NOSCANTIMEOUT := 1
 
 BSP_DEFINITIONS := $(wildcard hardware/*/*.def)
 BSP_HEADERS := $(patsubst hardware/%,bsp/%,$(BSP_DEFINITIONS))
@@ -154,6 +155,9 @@ ifeq ($(ENABLE_UART),1)
 CFLAGS += -DENABLE_UART
 endif
 LDFLAGS = -mcpu=cortex-m0 -nostartfiles -Wl,-T,firmware.ld
+ifeq ($(ENABLE_NOSCANTIMEOUT),1)
+CFLAGS += -DENABLE_NOSCANTIMEOUT
+endif
 
 ifeq ($(DEBUG),1)
 ASFLAGS += -g

--- a/app/app.c
+++ b/app/app.c
@@ -1233,6 +1233,7 @@ void APP_TimeSlice500ms(void)
 
 	if (gScreenToDisplay == DISPLAY_SCANNER && gScannerEditState == 0 && gScanCssState < SCAN_CSS_STATE_FOUND) {
 		gScanProgressIndicator++;
+#ifndef ENABLE_NOSCANTIMEOUT					
 		if (gScanProgressIndicator > 32) {
 			if (gScanCssState == SCAN_CSS_STATE_SCANNING && !gScanSingleFrequency) {
 				gScanCssState = SCAN_CSS_STATE_FOUND;
@@ -1240,6 +1241,7 @@ void APP_TimeSlice500ms(void)
 				gScanCssState = SCAN_CSS_STATE_FAILED;
 			}
 		}
+#endif	  
 		gUpdateDisplay = true;
 	}
 

--- a/app/menu.c
+++ b/app/menu.c
@@ -321,7 +321,11 @@ void MENU_AcceptSetting(void)
 	case MENU_MEM_CH:
 		gTxVfo->CHANNEL_SAVE = gSubMenuSelection;
 		gRequestSaveChannel = 2;
+#ifndef ENABLE_KEEPNAMEONSAVE														   									 
 		gEeprom.MrChannel[0] = gSubMenuSelection;
+#else
+		gEeprom.MrChannel[gEeprom.TX_CHANNEL] = gSubMenuSelection;
+#endif
 		return;
 
 	case MENU_SAVE:
@@ -682,7 +686,11 @@ void MENU_ShowCurrentSetting(void)
 		break;
 
 	case MENU_MEM_CH:
+#ifndef ENABLE_KEEPNAMEONSAVE														   
 		gSubMenuSelection = gEeprom.MrChannel[0];
+#else
+		gSubMenuSelection = gEeprom.MrChannel[gEeprom.TX_CHANNEL];
+#endif		 
 		break;
 
 	case MENU_SAVE:
@@ -822,7 +830,11 @@ void MENU_ShowCurrentSetting(void)
 #endif
 
 	case MENU_DEL_CH:
+#ifndef ENABLE_KEEPNAMEONSAVE															   
 		gSubMenuSelection = RADIO_FindNextChannel(gEeprom.MrChannel[0], 1, false, 1);
+#else
+		gSubMenuSelection = RADIO_FindNextChannel(gEeprom.MrChannel[gEeprom.TX_CHANNEL], 1, false, 1);
+#endif	 
 		break;
 
 	case MENU_350TX:

--- a/settings.c
+++ b/settings.c
@@ -230,9 +230,19 @@ void SETTINGS_SaveChannel(uint8_t Channel, uint8_t VFO, const VFO_Info_t *pVFO, 
 			SETTINGS_UpdateChannel(Channel, pVFO, true);
 
 			if (IS_MR_CHANNEL(Channel)) {
+#ifndef ENABLE_KEEPNAMEONSAVE					
 				memset(&State32, 0xFF, sizeof(State32));
 				EEPROM_WriteBuffer(OffsetMR + 0x0F50, State32);
 				EEPROM_WriteBuffer(OffsetMR + 0x0F58, State32);
+#else				  
+				if (Mode >= 3) {	// save the channel name - source OneOfEleven
+					memmove(State8, pVFO->Name + 0, 8);
+					EEPROM_WriteBuffer(0x0F50 + OffsetMR, State8);
+					memset(State8, 0xFF, sizeof(State8));
+					memmove(State8, pVFO->Name + 8, 2);
+					EEPROM_WriteBuffer(0x0F58 + OffsetMR, State8);
+				}
+#endif													 
 			}
 		}
 	}


### PR DESCRIPTION
Disable (with Makefile flag) the 32 second timeout before a frequency/ctcss scan fails.  Scan will continue to run until the Exit key is pressed.

Add Makefile flag to preserve the name of a MR channel when changes are saved.