### PR TITLE
Keep freq/ctcss scan results on screen until exit is pressed

### DIFF
--- a/app/app.c
+++ b/app/app.c
@@ -1177,14 +1177,14 @@ void APP_TimeSlice500ms(void)
 						gAskToSave = false;
 						gAskToDelete = false;
 #if defined(ENABLE_FMRADIO)
-						if (gFmRadioMode && gCurrentFunction != FUNCTION_RECEIVE && gCurrentFunction != FUNCTION_MONITOR && gCurrentFunction != FUNCTION_TRANSMIT) {
+						if (gFmRadioMode && gCurrentFunction != FUNCTION_RECEIVE && gCurrentFunction != FUNCTION_MONITOR && gCurrentFunction != FUNCTION_TRANSMIT)
 							GUI_SelectNextDisplay(DISPLAY_FM);
-						} else {
-							GUI_SelectNextDisplay(DISPLAY_MAIN);
-						}
-#else
-						GUI_SelectNextDisplay(DISPLAY_MAIN);
+						else
 #endif
+#if defined(ENABLE_NOSCANTIMEOUT)
+						if (gScreenToDisplay != DISPLAY_SCANNER)
+#endif
+							GUI_SelectNextDisplay(DISPLAY_MAIN);
 					}
 				}
 			}


### PR DESCRIPTION
Keep the scan results on the screen until exit is pressed instead of timing out after a few seconds.  Change imported from OneOfEleven.