### PR TITLE
Dockerfile modified to build much faster, compile-with-docker script …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 *.o
 *.d
-firmware
-firmware.bin
-firmware.packed.bin
+/compiled-firmware
 link-overlay.S
 sram-overlay
 sram-overlay.bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM archlinux:latest
-WORKDIR /app
-COPY . .
 RUN pacman -Syyu base-devel --noconfirm
 RUN pacman -Syyu arm-none-eabi-gcc --noconfirm
 RUN pacman -Syyu arm-none-eabi-newlib --noconfirm
 RUN pacman -Syyu git --noconfirm
+RUN pacman -Syyu python-pip --noconfirm
+RUN pacman -Syyu python-crcmod --noconfirm
+WORKDIR /app
+COPY . .
 
 RUN git submodule update --init --recursive
 #RUN make && cp firmware* compiled-firmware/

--- a/compile-with-docker.bat
+++ b/compile-with-docker.bat
@@ -1,0 +1,3 @@
+@echo off
+docker build -t uvk5 .
+docker run -v %CD%\compiled-firmware:/app/compiled-firmware uvk5 /bin/bash -c "cd /app && make && cp firmware* compiled-firmware/"


### PR DESCRIPTION
…for windows

Because Dockerfile `COPY . .` line modifies the intermediate docker image all subsequent intermediate images has to be rebuilt also. Moving it to the end causes most of the intermediates to be reused which is much much faster.