### PR TITLE
Dockerfile refactor, windows script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # hadolint ignore=DL3007
 FROM archlinux:latest
 
-WORKDIR /app
-
-COPY . .
-
 RUN set -eux; \
   pacman -Syy --noconfirm \
   arm-none-eabi-gcc \
@@ -12,5 +8,9 @@ RUN set -eux; \
   base-devel \
   git \
   python-crcmod
+
+WORKDIR /app
+
+COPY . .
 
 RUN git submodule update --init --recursive

--- a/compile-with-docker.bat
+++ b/compile-with-docker.bat
@@ -1,0 +1,4 @@
+@echo off
+docker build -t uvk5 .
+docker run -v %CD%\compiled-firmware:/app/compiled-firmware uvk5 /bin/bash -c "cd /app && make clean && make && cp firmware* compiled-firmware/"
+pause


### PR DESCRIPTION
Each command creates a new intermediate image based on the one before if you copy first all subsequent images has to be rebuilt from scratch. If you copy last, cached images are reused and it all build much much faster.

By the way can you tell me which branch is the best to use?